### PR TITLE
Adding missing treasury report types to the public API docs

### DIFF
--- a/treasury_report_samples/Tax_adjustment_payable.csv
+++ b/treasury_report_samples/Tax_adjustment_payable.csv
@@ -1,0 +1,15 @@
+tax_transaction_id,settlement_amount,currency,transaction_date
+tax_transaction_id,55.24,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,2.29,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,0.02,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,16.58,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,0.01,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,130.01,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,5.41,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,21.18,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,39.40,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,3.72,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,1.67,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,2.03,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,1.48,EUR,2024-11-01T00:00:00Z
+tax_transaction_id,0.37,EUR,2024-11-01T00:00:00Z


### PR DESCRIPTION
Add Tax_adjustment_payable.csv in treasury_report_samples